### PR TITLE
Relax php constraint as per 2025-11-03 TSC meeting

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,7 @@
     },
     "abandoned": true,
     "require": {
-        "php": "~8.0.0 || ~8.1.0 || ~8.2.0 || ~8.3.0 || ~8.4.0"
+        "php": "^8.0.0"
     },
     "require-dev": {
         "laminas/laminas-coding-standard": "~2.4.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "b2aa769d634ef91ad48c86aa033edd20",
+    "content-hash": "397df6711f260409037a70f2163edaff",
     "packages": [],
     "packages-dev": [
         {
@@ -2101,12 +2101,12 @@
     ],
     "aliases": [],
     "minimum-stability": "stable",
-    "stability-flags": [],
+    "stability-flags": {},
     "prefer-stable": false,
     "prefer-lowest": false,
     "platform": {
-        "php": "~8.0.0 || ~8.1.0 || ~8.2.0 || ~8.3.0 || ~8.4.0"
+        "php": "^8.0.0"
     },
-    "platform-dev": [],
-    "plugin-api-version": "2.6.0"
+    "platform-dev": {},
+    "plugin-api-version": "2.9.0"
 }


### PR DESCRIPTION
As per 2025-11-03 TSC meeting PHP version in abandoned and archived components is relaxed to facilitate upgrades and migration.

This component MIGHT work with newer php version however no such guarantee is provided.